### PR TITLE
[GATE 1775] User agent

### DIFF
--- a/src/VivialConnect/Transport/Connection.php
+++ b/src/VivialConnect/Transport/Connection.php
@@ -109,7 +109,8 @@ class Connection
     /** @var array  */
     protected $options = [
         self::OPTION_BASE_URI => "https://api.vivialconnect.net/api/v1.0/",
-        self::OPTION_DEFAULT_HEADERS => [],
+        self::OPTION_DEFAULT_HEADERS => ["Accept" => "application/json",
+                                         "User-Agent" => "VivialConnect PHPClient"],
         self::OPTION_DEFAULT_QUERY_PARAMS => [],
         self::OPTION_REQUEST_BODY_FORMAT => 'json',
         self::OPTION_ERROR_CLASS => 'VivialConnect\\Common\\Error',
@@ -250,6 +251,19 @@ class Connection
                 $body = http_build_query($body, null, '&');
             }
         }
+        # Parse host from URL
+        $matches = [];
+        $matched = preg_match("/:\/\/([^\/]+)\//i", $this->getOption(self::OPTION_BASE_URI), $matches);
+        $host = $matches[1];
+        $headers['Host'] = $host;
+
+        # Generate X-VivialConnect-User-Agent
+        $xUserAgent = ['lang_version' => phpversion(),
+                       'publisher' => 'vivialconnect',
+                       'platform' => php_uname('s') . ' ' . php_uname('r') . ' ' . php_uname('m') . ' ' . php_uname('v'),
+                       'lang' => 'PHP'];
+        $headers['X-VivialConnect-User-Agent'] = json_encode($xUserAgent);
+
         // If we have a falsey body, set body to null
         if (empty($body)) {
             $body = null;


### PR DESCRIPTION
Example HTTP headers:
```
{"Accept":"application\/json",
 "Authorization":"HMAC MTK4AHJ1NB8QBEPPRAKKDJ9AK2L0Z5GBPOU:9dd37faa28886d72e3861e958cc4ca91daa4debdeb27cc42ae26486a99cee922",
 "Content-Type":"application\/json",
 "Date":"Tue, 05 Dec 2017 18:36:59 GMT",
 "Host":"api-stage-8c935d.moosetalk.net",
 "User-Agent":"VivialConnect PHPClient",
 "X-Auth-Date":"20171205T183659Z",
 "X-Auth-SignedHeaders":"accept;date",
 "X-VivialConnect-User-Agent":"{\"lang_version\":\"7.0.22-0ubuntu0.16.04.1\",
 \"publisher\":\"vivialconnect\",
 \"platform\":\"Linux 4.10.0-40-generic x86_64 #44~16.04.1-Ubuntu SMP Thu Nov 9 15:37:44 UTC 2017\",
 \"lang\":\"PHP\"}",
}
```